### PR TITLE
add button group for hero carousel

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -50,6 +50,7 @@
         "lodash": "^4.17.21",
         "lucide-react": "^0.545.0",
         "luxon": "^2.5.2",
+        "motion": "^12.23.25",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-hot-toast": "^2.4.0",
@@ -7229,6 +7230,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.25",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.25.tgz",
+      "integrity": "sha512-gUHGl2e4VG66jOcH0JHhuJQr6ZNwrET9g31ZG0xdXzT0CznP7fHX4P8Bcvuc4MiUB90ysNnWX2ukHRIggkl6hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.23",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -8994,6 +9022,47 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion": {
+      "version": "12.23.25",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.23.25.tgz",
+      "integrity": "sha512-Fk5Y1kcgxYiTYOUjmwfXQAP7tP+iGqw/on1UID9WEL/6KpzxPr9jY2169OsjgZvXJdpraKXy0orkjaCVIl5fgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.23.25",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.23",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.23.tgz",
+      "integrity": "sha512-n5yolOs0TQQBRUFImrRfs/+6X4p3Q4n1dUEqt/H58Vx7OW6RF+foWEgmTVDhIWJIMXOuNNL0apKH2S16en9eiA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/ui/package.json
+++ b/ui/package.json
@@ -45,6 +45,7 @@
     "lodash": "^4.17.21",
     "lucide-react": "^0.545.0",
     "luxon": "^2.5.2",
+    "motion": "^12.23.25",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hot-toast": "^2.4.0",

--- a/ui/src/components/HomePage/HeroCarousel.tsx
+++ b/ui/src/components/HomePage/HeroCarousel.tsx
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useState } from "react";
 import Autoplay from "embla-carousel-autoplay";
 import { Button } from "@/components/ui/button";
 import { slides } from "@/constants/carouselProducts"
+import { GradientText } from '@/components/shadcn-io/GradientText';
 
 export default function HeroCarousel() {
   const [carouselAPI, setCarouselAPI] = useState(null);
@@ -55,7 +56,7 @@ export default function HeroCarousel() {
                 {/* gradient overlay */}
                 <div className="absolute inset-0 bg-gradient-to-t from-black/55 to-transparent" />
                 <div className="absolute inset-0 flex flex-col items-center text-chart-2 justify-center p-8 text-center">
-                  <h2 className="mb-2 font-bold text-shadow-md  tracking-tight text-6xl">{slide.title}</h2>
+                  <GradientText className="mb-2 font-bold text-shadow-md  tracking-tight text-6xl" text={slide.title}/>
                   <p className="mb-6 max-w-md text-sm text-white opacity-90">
                     {slide.description}
                   </p>

--- a/ui/src/components/HomePage/HeroCarousel.tsx
+++ b/ui/src/components/HomePage/HeroCarousel.tsx
@@ -2,32 +2,43 @@ import {
   Carousel,
   CarouselContent,
   CarouselItem,
-  CarouselNext,
-  CarouselPrevious,
 } from "@/components/ui/carousel";
-import { useCallback, useEffect, useState } from "react";
-import Autoplay from "embla-carousel-autoplay";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { slides } from "@/constants/carouselProducts"
 import { GradientText } from '@/components/shadcn-io/GradientText';
+import ButtonGroup from "@/components/shadcn-io/ButtonGroup";
 
 export default function HeroCarousel() {
   const [carouselAPI, setCarouselAPI] = useState(null);
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  const [scrollSnaps, setScrollSnaps] = useState([]);
 
-  const onSelect = useCallback(() => {
-    if (!carouselAPI) return;
-    setSelectedIndex(carouselAPI.selectedScrollSnap());
-  }, [carouselAPI]);
+  // Check state
+  const canScrollNext = carouselAPI?.canScrollNext();
+  const currentPrev = carouselAPI?.canScrollPrev();
+  const isPlaying = carouselAPI?.onPlaying();
 
-  const scrollTo = (index) => {
+
+  const scrollPrev = () => {
     if (!carouselAPI) return;
-    carouselAPI.scrollTo(index);
+    carouselAPI.scrollPrev();
+  };
+
+  const play = () => {
+    if (!carouselAPI) return;
+    carouselAPI.play();
+  };
+
+  const pause = () => {
+    if (!carouselAPI) return;
+    carouselAPI.pause();
+  };
+
+  const scrollNext = () => {
+    if (!carouselAPI) return;
+    carouselAPI.scrollNext();
   };
 
   useEffect(() => {
-    if (!carouselAPI) return;
     onSelect();
     setScrollSnaps(carouselAPI.scrollSnapList());
     carouselAPI.on("select", onSelect);
@@ -38,8 +49,6 @@ export default function HeroCarousel() {
   return (
     <section className="max-w-7xl mx-auto w-full">
       <Carousel
-        plugins={[Autoplay({ delay: 3500 })]}
-        opts={{ loop: true, align: "center" }}
         setApi={setCarouselAPI}
       >
         <CarouselContent>
@@ -66,8 +75,19 @@ export default function HeroCarousel() {
             </CarouselItem>
           ))}
         </CarouselContent>
-        <CarouselPrevious className="left-4" />
-        <CarouselNext className="right-4" />
+        <ButtonGroup className="right-12 bottom-8" play={play} scrollPrev={scrollPrev} scrollNext={scrollNext} canScrollPrev={currentPrev} canScrollNext={canScrollNext} isPlaying={isPlaying} pause={pause}/>
+        <div className="flex justify-center mt-4 space-x-2">
+          {scrollSnaps.map((_, index) => (
+            <Button
+              key={index}
+              onClick={() => scrollTo(index)}
+              size="icon"
+              className={`w-2 h-2 rounded-full ${
+                selectedIndex === index ? "bg-primary" : "bg-gray-300"
+              }`}
+            />
+          ))}
+        </div>
       </Carousel>
     </section>
   );

--- a/ui/src/components/HomePage/HeroCarousel.tsx
+++ b/ui/src/components/HomePage/HeroCarousel.tsx
@@ -3,53 +3,71 @@ import {
   CarouselContent,
   CarouselItem,
 } from "@/components/ui/carousel";
-import { useEffect, useState } from "react";
+import Autoplay from 'embla-carousel-autoplay';
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { slides } from "@/constants/carouselProducts"
 import { GradientText } from '@/components/shadcn-io/GradientText';
-import ButtonGroup from "@/components/shadcn-io/ButtonGroup";
+import CarouselButtonGroup from "@/components/shadcn-io/ButtonGroup";
+import { useAutoplay } from "@/lib/utils";
 
 export default function HeroCarousel() {
   const [carouselAPI, setCarouselAPI] = useState(null);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [scrollSnaps, setScrollSnaps] = useState<number[]>([]);
+  const {isPlaying, setIsPlaying} = useAutoplay(carouselAPI);
 
-  // Check state
-  const canScrollNext = carouselAPI?.canScrollNext();
-  const currentPrev = carouselAPI?.canScrollPrev();
-  const isPlaying = carouselAPI?.onPlaying();
+  const autoplay = useRef(
+    Autoplay(
+      {
+        delay: 4000,
+        stopOnInteraction: false,
+        stopOnMouseEnter: false,
+        playOnInit: true,
+      },
+      (carouselRoot) => carouselRoot
+    )
+  );
 
 
-  const scrollPrev = () => {
+
+
+  const onSelect = useCallback(() => {
+    if (!carouselAPI) return;
+
+    setSelectedIndex(carouselAPI.selectedScrollSnap());
+  }, [carouselAPI]);
+
+  const scrollPrev = useCallback(() => {
     if (!carouselAPI) return;
     carouselAPI.scrollPrev();
-  };
+  },  [carouselAPI]);
 
-  const play = () => {
-    if (!carouselAPI) return;
-    carouselAPI.play();
-  };
-
-  const pause = () => {
-    if (!carouselAPI) return;
-    carouselAPI.pause();
-  };
-
-  const scrollNext = () => {
+  const scrollNext = useCallback(() => {
     if (!carouselAPI) return;
     carouselAPI.scrollNext();
+  },  [carouselAPI]);
+
+  /************ renamed method to scrollToIndex from scrollTo as there is an inbuilt scrollTo method ***/
+  const scrollToIndex = (index: number) => {
+    if (!carouselAPI) return;
+    carouselAPI.scrollTo(index);
   };
 
   useEffect(() => {
+    if (!carouselAPI) return;
     onSelect();
     setScrollSnaps(carouselAPI.scrollSnapList());
     carouselAPI.on("select", onSelect);
   }, [carouselAPI, onSelect]);
 
 
-
   return (
     <section className="max-w-7xl mx-auto w-full">
       <Carousel
         setApi={setCarouselAPI}
+        plugins={[autoplay.current]}
+        opts={{ loop: true, align: "center" }}
       >
         <CarouselContent>
           {slides.map((slide, index) => (
@@ -75,12 +93,12 @@ export default function HeroCarousel() {
             </CarouselItem>
           ))}
         </CarouselContent>
-        <ButtonGroup className="right-12 bottom-8" play={play} scrollPrev={scrollPrev} scrollNext={scrollNext} canScrollPrev={currentPrev} canScrollNext={canScrollNext} isPlaying={isPlaying} pause={pause}/>
+        <CarouselButtonGroup className="right-12 bottom-8"  autoplay={autoplay} scrollPrev={scrollPrev} scrollNext={scrollNext} isPlaying={isPlaying} />
         <div className="flex justify-center mt-4 space-x-2">
           {scrollSnaps.map((_, index) => (
             <Button
               key={index}
-              onClick={() => scrollTo(index)}
+              onClick={() => scrollToIndex(index)}
               size="icon"
               className={`w-2 h-2 rounded-full ${
                 selectedIndex === index ? "bg-primary" : "bg-gray-300"

--- a/ui/src/components/HomePage/ProductCard/ProductCard.tsx
+++ b/ui/src/components/HomePage/ProductCard/ProductCard.tsx
@@ -109,8 +109,8 @@ const ProductCard = ({title, imgUrl, description}) => {
   return (
     <Card ref={cardRef} className='max-w-sm border-0'>
       <CardHeader className='flex flex-row justify-between'>
-        <CardTitle className="text-xs text-shadow font-semibold">{title}</CardTitle>
-        <Badge className='rounded-full text-xs text-gray-600 font-semibold'>
+        <CardTitle className="text-md text-shadow font-extrabold">{title}</CardTitle>
+        <Badge className='rounded-full text-sm text-gray-600 font-extrabold'>
           <span >UGX</span> 38,000
         </Badge>
       </CardHeader>
@@ -127,8 +127,8 @@ const ProductCard = ({title, imgUrl, description}) => {
           <CardDescription className="line-clamp-2 mb-6">
             {description} {additionalDescription}
           </CardDescription>
-        <Button className='inline-flex text-shadow text-shadow-amber-600 gap-2 px-2'>Detailed View <ArrowRight className='h-4 w-4' /></Button>
-        <Button variant={'outline'}  className='inline-flex text-shadow text-shadow-amber-600 gap-2 px-2'>Show Phone <PhoneForwarded className='h-4 w-4' /></Button>
+        <Button className='inline-flex text-md font-extrabold text-shadow gap-2 px-2'>Detailed View <ArrowRight strokeWidth={3} className='h-4 w-4 text-md font-extrabold' /></Button>
+        <Button variant={'outline'}  className='inline-flex text-md font-extrabold text-shadow gap-2 px-2'>Show Phone <PhoneForwarded strokeWidth={3} className='h-4 w-4' /></Button>
         </div>
       </CardFooter>
     </Card>

--- a/ui/src/components/HomePage/ProductCard/SlimProductCard.tsx
+++ b/ui/src/components/HomePage/ProductCard/SlimProductCard.tsx
@@ -10,8 +10,8 @@ const SlimProductCard = ({title, imgUrl, description}) => {
   return (
     <Card className='max-w-sm border-0 grid grid-cols-subgrid'>
       <CardHeader className='flex space-y-2 px-3'>
-        <CardTitle className="text-xs font-bold line-clamp-1 text-shadow">{title}</CardTitle>
-        <Badge className='rounded-full text-gray-600 font-bold'>
+        <CardTitle className="text-xs font-extrabold line-clamp-1 text-shadow">{title}</CardTitle>
+        <Badge className='rounded-full text-xs text-gray-600 font-extrabold'>
           <span >UGX</span> 38,000
         </Badge>
       </CardHeader>
@@ -27,8 +27,9 @@ const SlimProductCard = ({title, imgUrl, description}) => {
           <CardDescription className="line-clamp-2">
             {description}
           </CardDescription>
-          <Button className='inline-flex text-xs font-bold text-shadow text-shadow-amber-600 gap-2 px-2'>Details<ArrowRight className='h-2 w-2 font-bold' /></Button>
-          <Button variant={'outline'} className='inline-flex text-sx font-bold text-shadow text-shadow-amber-600 gap-2 px-2'>Show<PhoneForwarded className='h-2 w-2' /></Button>
+          <Button className='inline-flex text-md font-extrabold text-shadow gap-2 px-2'>Details<ArrowRight
+            strokeWidth={3} className='h-2 w-2 font-bold' /></Button>
+          <Button variant={'outline'} className='inline-flex text-md font-extrabold text-shadow  gap-2 px-2'>Show<PhoneForwarded strokeWidth={3} className='h-2 w-2' /></Button>
         </div>
       </CardFooter>
     </Card>

--- a/ui/src/components/shadcn-io/ButtonGroup.tsx
+++ b/ui/src/components/shadcn-io/ButtonGroup.tsx
@@ -34,7 +34,7 @@ const CarouselButtonGroup = (props:Props) => {
             <span className='sr-only'>Scroll Right</span>
           </Button>
         </TooltipTrigger>
-        <TooltipContent className='px-2 py-1 text-xs'>Scroll right</TooltipContent>
+        <TooltipContent className='px-2 py-1 text-xs'>Scroll Right</TooltipContent>
       </Tooltip>
       <Tooltip>
         <TooltipTrigger asChild>

--- a/ui/src/components/shadcn-io/ButtonGroup.tsx
+++ b/ui/src/components/shadcn-io/ButtonGroup.tsx
@@ -4,17 +4,14 @@ import { Button } from "@/components/ui/button";
 import { cn } from '@/lib/utils';
 
 interface Props {
-  isPlaying: boolean
-  play: () => void
-  pause: () => void
+  autoplay: unknown
   scrollPrev: () => void
   scrollNext: () => void
+  isPlaying: boolean
   className: string
-  canScrollNext: boolean
-  canScrollPrev: boolean
 }
-const ButtonGroup = (props:Props) => {
-  const { isPlaying, play, pause, scrollPrev, scrollNext, canScrollPrev, canScrollNext, className} = props;
+const CarouselButtonGroup = (props:Props) => {
+  const {  autoplay, scrollPrev, scrollNext, isPlaying, className} = props;
 
   return (
     <>
@@ -23,7 +20,7 @@ const ButtonGroup = (props:Props) => {
       className={cn('absolute divide-primary-foreground/30 inline-flex w-fit divide-x rounded-md shadow-xs', className)}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <Button onClick={scrollPrev} type="button" className='rounded-none rounded-l-full focus-visible:z-10' disabled={canScrollPrev}>
+          <Button onClick={scrollPrev} type="button" className='rounded-none rounded-l-full focus-visible:z-10'>
             <ChevronLeft />
             <span className='sr-only'>Scroll left</span>
           </Button>
@@ -32,36 +29,37 @@ const ButtonGroup = (props:Props) => {
       </Tooltip>
       <Tooltip>
         <TooltipTrigger asChild>
-          <Button onClick={scrollNext} type="button" className='rounded-none focus-visible:z-10' disabled={canScrollNext}>
+          <Button onClick={scrollNext} type="button" className='rounded-none focus-visible:z-10'>
             <ChevronRight />
             <span className='sr-only'>Scroll Right</span>
           </Button>
         </TooltipTrigger>
         <TooltipContent className='px-2 py-1 text-xs'>Scroll right</TooltipContent>
       </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            onClick={() =>
+              isPlaying
+                ? autoplay.current.stop()
+                : autoplay.current.play()
+            }
+            className="rounded-none rounded-r-full focus-visible:z-10"
+          >
+            {isPlaying ? <PauseIcon /> : <PlayIcon />}
+            <span className="sr-only">{isPlaying ? "Pause" : "Play"}</span>
+          </Button>
+        </TooltipTrigger>
 
-      {isPlaying?
-        (<Tooltip>
-          <TooltipTrigger asChild>
-            <Button onClick={play} type="button" className='rounded-none focus-visible:z-10'>
-              <PauseIcon />
-              <span className='sr-only'>Pause</span>
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent className='px-2 py-1 text-xs'>Pause</TooltipContent>
-        </Tooltip> ):
-        (<Tooltip>
-          <TooltipTrigger asChild>
-            <Button onClick={pause} type="button" className='rounded-none rounded-r-full focus-visible:z-10'>
-              <PlayIcon />
-              <span className='sr-only'>Play Slides</span>
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent className='px-2 py-1 text-xs'>Play Slides</TooltipContent>
-        </Tooltip>)}
+        <TooltipContent className="px-2 py-1 text-xs">
+          {isPlaying ? "Pause" : "Play Slides"}
+        </TooltipContent>
+      </Tooltip>
+
     </div>
     </>
   )
 }
 
-export default ButtonGroup;
+export default CarouselButtonGroup;

--- a/ui/src/components/shadcn-io/ButtonGroup.tsx
+++ b/ui/src/components/shadcn-io/ButtonGroup.tsx
@@ -1,0 +1,67 @@
+import { PauseIcon, PlayIcon, ChevronRight, ChevronLeft } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { Button } from "@/components/ui/button";
+import { cn } from '@/lib/utils';
+
+interface Props {
+  isPlaying: boolean
+  play: () => void
+  pause: () => void
+  scrollPrev: () => void
+  scrollNext: () => void
+  className: string
+  canScrollNext: boolean
+  canScrollPrev: boolean
+}
+const ButtonGroup = (props:Props) => {
+  const { isPlaying, play, pause, scrollPrev, scrollNext, canScrollPrev, canScrollNext, className} = props;
+
+  return (
+    <>
+    {/******** Enable absolute positioning to mimic the CarouselPrev/Next components **************/}
+    <div
+      className={cn('absolute divide-primary-foreground/30 inline-flex w-fit divide-x rounded-md shadow-xs', className)}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button onClick={scrollPrev} type="button" className='rounded-none rounded-l-full focus-visible:z-10' disabled={canScrollPrev}>
+            <ChevronLeft />
+            <span className='sr-only'>Scroll left</span>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent className='px-2 py-1 text-xs'>Scroll Left</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button onClick={scrollNext} type="button" className='rounded-none focus-visible:z-10' disabled={canScrollNext}>
+            <ChevronRight />
+            <span className='sr-only'>Scroll Right</span>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent className='px-2 py-1 text-xs'>Scroll right</TooltipContent>
+      </Tooltip>
+
+      {isPlaying?
+        (<Tooltip>
+          <TooltipTrigger asChild>
+            <Button onClick={play} type="button" className='rounded-none focus-visible:z-10'>
+              <PauseIcon />
+              <span className='sr-only'>Pause</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent className='px-2 py-1 text-xs'>Pause</TooltipContent>
+        </Tooltip> ):
+        (<Tooltip>
+          <TooltipTrigger asChild>
+            <Button onClick={pause} type="button" className='rounded-none rounded-r-full focus-visible:z-10'>
+              <PlayIcon />
+              <span className='sr-only'>Play Slides</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent className='px-2 py-1 text-xs'>Play Slides</TooltipContent>
+        </Tooltip>)}
+    </div>
+    </>
+  )
+}
+
+export default ButtonGroup;

--- a/ui/src/components/shadcn-io/ButtonGroup.tsx
+++ b/ui/src/components/shadcn-io/ButtonGroup.tsx
@@ -42,8 +42,8 @@ const CarouselButtonGroup = (props:Props) => {
             type="button"
             onClick={() =>
               isPlaying
-                ? autoplay.current.stop()
-                : autoplay.current.play()
+                ? autoplay.current?.stop()
+                : autoplay.current?.play()
             }
             className="rounded-none rounded-r-full focus-visible:z-10"
           >

--- a/ui/src/components/shadcn-io/GradientText.tsx
+++ b/ui/src/components/shadcn-io/GradientText.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { motion, type Transition } from 'motion/react';
-
 import { cn } from '@/lib/utils';
 
 type GradientTextProps = React.ComponentProps<'span'> & {

--- a/ui/src/components/shadcn-io/GradientText.tsx
+++ b/ui/src/components/shadcn-io/GradientText.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { motion, type Transition } from 'motion/react';
+
+import { cn } from '@/lib/utils';
+
+type GradientTextProps = React.ComponentProps<'span'> & {
+  text: string;
+  gradient?: string;
+  neon?: boolean;
+  transition?: Transition;
+};
+
+function GradientText({
+                        text,
+                        className,
+                        gradient = 'linear-gradient(45deg, #84170ffb, #f59e0b, #b45309, #78350f, #721109)',
+                        neon = false,
+                        transition = { duration: 3, repeat: Infinity, ease: 'linear' },
+                        ...props
+                      }: GradientTextProps) {
+  const baseStyle: React.CSSProperties = {
+    backgroundImage: gradient,
+  };
+
+  return (
+    <span
+      data-slot="gradient-text"
+      className={cn('relative inline-block', className)}
+      {...(props as any)}
+    >
+      <motion.span
+        className="m-0 text-transparent bg-clip-text bg-[length:200%_100%]"
+        style={baseStyle}
+        animate={{ backgroundPositionX: ['0%', '200%'] }}
+        transition={transition}
+      >
+        {text}
+      </motion.span>
+
+      {neon && (
+        <motion.span
+          className="m-0 absolute top-0 left-0 text-transparent bg-clip-text blur-[8px] mix-blend-plus-lighter bg-[length:200%_100%]"
+          style={baseStyle}
+          animate={{ backgroundPositionX: ['0%', '200%'] }}
+          transition={transition}
+        >
+          {text}
+        </motion.span>
+      )}
+    </span>
+  );
+}
+
+export { GradientText, type GradientTextProps };

--- a/ui/src/components/ui/tooltip.tsx
+++ b/ui/src/components/ui/tooltip.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 
 import { cn } from "@/lib/utils";
+import { forwardRef } from "react";
 
 function TooltipProvider({ delayDuration = 0, ...props }) {
   return (
@@ -13,22 +14,23 @@ function TooltipProvider({ delayDuration = 0, ...props }) {
   );
 }
 
-function Tooltip({ ...props }) {
+const Tooltip = forwardRef(({ ...props }, ref) => {
   return (
     <TooltipProvider>
-      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+      <TooltipPrimitive.Root data-slot="tooltip" ref={ref} {...props} />
     </TooltipProvider>
   );
-}
+});
 
 function TooltipTrigger({ ...props }) {
   return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
 }
 
-function TooltipContent({ className, sideOffset = 0, children, ...props }) {
+const TooltipContent = forwardRef(({ className, sideOffset = 0, children, ...props }, ref) => {
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Content
+        ref={ref}
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
@@ -42,6 +44,6 @@ function TooltipContent({ className, sideOffset = 0, children, ...props }) {
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   );
-}
+});
 
 export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added carousel navigation controls (prev/next and play/pause) with manual dot indicators
  * Introduced gradient-styled, animated text for carousel titles
  * Autoplay now uses a centralized instance with updated initial delay (4s)
  * Added a reusable carousel button group component

* **Style**
  * Increased typography weight across product cards for stronger visual hierarchy
  * Updated button and icon styling for clearer emphasis and consistency

* **Accessibility**
  * Tooltip components now forward refs to improve focus and integration

* **Chore**
  * Added animation/runtime dependency for motion-driven effects

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->